### PR TITLE
Convert Material Combiner to Blender 5.0 Extension & Version 3.0.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,18 +27,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-bl_info = {
-    "name": "Shotariya's Material Combiner",
-    "description": "Advanced Texture Atlas Generation System",
-    "author": "shotariya",
-    "version": (2, 1, 3, 0),
-    "blender": (2, 80, 0),
-    "location": "View3D",
-    "wiki_url": "https://github.com/Grim-es/material-combiner-addon",
-    "tracker_url": "https://github.com/Grim-es/material-combiner-addon/issues",
-    "category": "Object",
-}
-
 from .registration import register_all, unregister_all  # noqa: E402
 
 
@@ -49,7 +37,7 @@ def register() -> None:
     It delegates to the registration module to initialize all components.
     """
     print("Loading Material Combiner..")
-    register_all(bl_info)
+    register_all()
 
 
 def unregister() -> None:

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -1077,7 +1077,7 @@ classes = (
 )
 
 
-def register(bl_info):
+def register():
     if Updater.error:
         print("Exiting updater registration, " + Updater.error)
         return
@@ -1085,13 +1085,13 @@ def register(bl_info):
     Updater.clear_state()
     Updater.engine = "Github"
     Updater.private_token = None
-    Updater.user = "Grim-es"
+    Updater.user = "teamneoneko"
     Updater.repo = "material-combiner-addon"
     Updater.website = (
-        "https://github.com/Grim-es/material-combiner-addon/archive/master.zip"
+        "https://github.com/teamneoneko/material-combiner-addon/archive/master.zip"
     )
     Updater.subfolder_path = ""
-    Updater.current_version = bl_info["version"]
+    Updater.current_version = (3, 0, 0, 0)
     Updater.verbose = False
     Updater.backup_current = False
     Updater.backup_ignore_patterns = ["*"]

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,35 @@
+schema_version = "1.0.0"
+
+id = "shotariyas_material_combiner"
+version = "3.0.0"
+name = "Shotariya's Material Combiner"
+tagline = "Advanced texture atlas generation system for optimized rendering"
+maintainer = "Neoneko"
+type = "add-on"
+
+blender_version_min = "5.0.0"
+
+license = [
+  "SPDX:MIT",
+]
+
+website = "https://github.com/teamneoneko/material-combiner-addon"
+
+tags = [
+  "Material",
+  "Optimization",
+  "UV",
+  "Texture",
+]
+
+# Required permissions for the addon
+[permissions]
+files = "Import/export texture atlases and manage external files"
+
+[build]
+paths_exclude_pattern = [
+  "__pycache__/",
+  ".*",
+  "*.zip",
+  "BLENDER_5_0_COMPATIBILITY_ANALYSIS.md",
+]

--- a/extend_lists.py
+++ b/extend_lists.py
@@ -7,7 +7,6 @@ their materials during filtering and sorting operations.
 """
 
 from typing import Any, Dict, List, Tuple
-
 import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty
 
@@ -16,7 +15,6 @@ from .globs import (
     ICON_OBJECT,
     ICON_PROPERTIES,
     CombineListTypes,
-    is_blender_modern,
 )
 
 
@@ -115,10 +113,7 @@ class SMC_UL_Combine_List(bpy.types.UIList):
             item: The material item to display.
             index: The index of the item in the list.
         """
-        if is_blender_modern:
-            row.separator(factor=1.5)
-        else:
-            row.separator()
+        row.separator(factor=1.5)
 
         self._draw_toggle_control(row, item, index)
 

--- a/globs.py
+++ b/globs.py
@@ -1,8 +1,7 @@
 """Global constants and configuration for the Material Combiner addon.
 
-This module contains version detection logic, global constants, and configuration
-variables used throughout the addon. It provides consistent access to version-specific
-features and establishes addon-wide settings.
+This module contains configuration variables and constants used throughout 
+the addon. Requires Blender 5.0+.
 """
 
 import importlib.util
@@ -20,14 +19,12 @@ pil_available = all(
 
 pil_install_attempted = False
 
-is_blender_legacy = bpy.app.version < (2, 80, 0)
-is_blender_modern = bpy.app.version >= (2, 80, 0)
-is_blender_2_92_plus = bpy.app.version >= (2, 92, 0)
-is_blender_3_plus = bpy.app.version >= (3, 0, 0)
+# Blender version checks (minimum version is now 5.0)
+is_blender_5_plus = bpy.app.version >= (5, 0, 0)
 
-ICON_OBJECT = "META_CUBE" if is_blender_modern else "VIEW3D"
-ICON_PROPERTIES = "PREFERENCES" if is_blender_modern else "SCRIPT"
-ICON_DROPDOWN = "THREE_DOTS" if is_blender_modern else "DOWNARROW_HLT"
+ICON_OBJECT = "META_CUBE"
+ICON_PROPERTIES = "PREFERENCES"
+ICON_DROPDOWN = "THREE_DOTS"
 
 
 class CombineListTypes:

--- a/operators/combiner/combiner.py
+++ b/operators/combiner/combiner.py
@@ -142,13 +142,12 @@ class Combiner(bpy.types.Operator):
             return self._return_with_message(
                 "ERROR", "No valid objects selected"
             )
-
         if self.cats:
             scn.smc_size = "PO2"
             scn.smc_gaps = 0
 
         set_ob_mode(
-            context.view_layer if globs.is_blender_modern else scn,
+            context.view_layer,
             scn.smc_ob_data,
         )
         self.data = get_data(scn.smc_ob_data)
@@ -160,9 +159,6 @@ class Combiner(bpy.types.Operator):
         clear_empty_mats(scn, self.data, self.mats_uv)
         get_duplicates(self.mats_uv)
         self.structure = get_structure(scn, self.data, self.mats_uv)
-
-        if globs.is_blender_legacy:
-            context.space_data.viewport_shade = "MATERIAL"
 
         # Check if we're only dealing with duplicate materials
         total_unique_mats = len(self.structure)

--- a/operators/get_pillow.py
+++ b/operators/get_pillow.py
@@ -88,10 +88,7 @@ class InstallPIL(bpy.types.Operator):
             True if pip installation succeeds, False otherwise.
         """
         try:
-            if globs.is_blender_modern:
-                return self._try_install_pip_with_ensurepip()
-            else:
-                return self._install_pip_clean()
+            return self._try_install_pip_with_ensurepip()
         except Exception as e:
             self.report({"ERROR"}, "Failed to install pip: {}".format(e))
             return False
@@ -123,11 +120,7 @@ class InstallPIL(bpy.types.Operator):
             True if pip installation succeeds, False otherwise.
         """
         try:
-            python_executable = (
-                sys.executable
-                if globs.is_blender_2_92_plus
-                else bpy.app.binary_path_python
-            )
+            python_executable = sys.executable
             get_pip = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)), "get-pip.py"
             )

--- a/operators/ui/combine_list.py
+++ b/operators/ui/combine_list.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Set, cast
 import bpy
 from bpy.props import IntProperty
 
-from ...globs import CombineListTypes, is_blender_3_plus
+from ...globs import CombineListTypes
 from ...type_annotations import CombineListData, Scene
 from ...utils.materials import get_materials
 
@@ -152,11 +152,10 @@ class MaterialListRefreshOperator(bpy.types.Operator):
     @staticmethod
     def _ensure_material_preview(material: bpy.types.Material) -> None:
         """Generate preview if missing in Blender 3.0+.
-
         Args:
             material: Material to ensure preview for.
         """
-        if is_blender_3_plus and not material.preview:
+        if not material.preview:
             material.preview_ensure()
 
     @staticmethod

--- a/registration.py
+++ b/registration.py
@@ -1,11 +1,9 @@
 """Registration module for the Material Combiner addon.
 
 This module handles the registration and unregistration of all Blender classes
-used by the addon. It also manages version-specific property annotations and
-initializes the icon system and updater functionality.
+used by the addon. It also manages property annotations and initializes the 
+icon system and updater functionality.
 """
-
-from typing import Dict, Union
 
 import bpy
 
@@ -43,18 +41,15 @@ __bl_classes = [
 ]
 
 
-def register_all(bl_info: Dict[str, Union[str, tuple]]) -> None:
+def register_all() -> None:
     """Register all components of the addon.
     
     This is the main registration function called when the addon is enabled.
     It registers all classes, initializes icons, and sets up the updater.
-    
-    Args:
-        bl_info: Dictionary containing addon metadata
     """
     _register_classes()
     initialize_smc_icons()
-    addon_updater_ops.register(bl_info)
+    addon_updater_ops.register()
     addon_updater_ops.check_for_update_background()
     extend_types.register()
 
@@ -107,8 +102,7 @@ def _unregister_classes() -> None:
 def make_annotations(cls: BlClasses) -> BlClasses:
     """Convert class properties to annotations for Blender 2.80+.
 
-    This function handles the transition from Blender's old property 
-    definition system to the new annotation-based system.
+    This function handles property definition for the extension system.
 
     Args:
         cls: Blender class to process.
@@ -116,13 +110,8 @@ def make_annotations(cls: BlClasses) -> BlClasses:
     Returns:
         The processed class with properties converted to annotations.
     """
-    if globs.is_blender_legacy:
-        return cls
-
-    if bpy.app.version >= (2, 93, 0):
-        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
-    else:
-        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+    # Blender 5.0+ uses _PropertyDeferred for properties
+    bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
 
     if bl_props:
         if '__annotations__' not in cls.__dict__:

--- a/type_annotations.py
+++ b/type_annotations.py
@@ -28,8 +28,8 @@ SMCIcons = Union[
     None,
 ]
 
-# Scene type that handles version differences
-Scene = bpy.types.ViewLayer if globs.is_blender_modern else bpy.types.Scene
+# Scene type - ViewLayer for Blender 5.0+
+Scene = bpy.types.ViewLayer
 
 # Object data structure for material mapping
 SMCObDataItem = Dict[bpy.types.Material, int]

--- a/ui/credits_panel.py
+++ b/ui/credits_panel.py
@@ -7,13 +7,11 @@ for reporting issues or supporting development.
 
 import bpy
 
-from .. import bl_info, globs
 from ..icons import get_icon_id
 
-DISCORD_URL = "https://discordapp.com/users/275608234595713024"
-GITHUB_ISSUES_URL = "https://github.com/Grim-es/material-combiner-addon/issues"
-PATREON_URL = "https://www.patreon.com/shotariya"
-BUYMEACOFFEE_URL = "https://buymeacoffee.com/shotariya"
+ADDON_VERSION = "3.0.0"
+DISCORD_URL = "https://discord.neoneko.xyz/"
+GITHUB_ISSUES_URL = "https://github.com/teamneoneko/material-combiner-addon/issues"
 
 
 class CreditsPanel(bpy.types.Panel):
@@ -27,7 +25,7 @@ class CreditsPanel(bpy.types.Panel):
     bl_label = "Credits & Support"
     bl_idname = "SMC_PT_Credits_Panel"
     bl_space_type = "VIEW_3D"
-    bl_region_type = "UI" if globs.is_blender_modern else "TOOLS"
+    bl_region_type = "UI"
     bl_category = "MatCombiner"
 
     def draw(self, context: bpy.types.Context) -> None:
@@ -52,9 +50,8 @@ class CreditsPanel(bpy.types.Panel):
         col = box.column()
         col.scale_y = 1.2
 
-        version_str = ".".join(map(str, bl_info["version"]))
         col.label(
-            text="Material Combiner {}".format(version_str),
+            text="Material Combiner {}".format(ADDON_VERSION),
             icon_value=get_icon_id("smc"),
         )
 
@@ -98,12 +95,9 @@ class CreditsPanel(bpy.types.Panel):
         col = box.column(align=True)
         col.scale_y = 1.2
 
-        col.label(text="Support Development:")
+        col.label(text="Report Issues:")
         self._create_link_button(
-            col, text="Patreon Support", icon="patreon", url=PATREON_URL
-        )
-        self._create_link_button(
-            col, text="Buy Me a Coffee", icon="bmc", url=BUYMEACOFFEE_URL
+            col, text="GitHub Issues", icon="github", url=GITHUB_ISSUES_URL
         )
 
     @staticmethod

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -30,7 +30,7 @@ class MaterialCombinerPanel(bpy.types.Panel):
     bl_label = 'Main Menu'
     bl_idname = 'SMC_PT_Main_Panel'
     bl_space_type = 'VIEW_3D'
-    bl_region_type = 'UI' if globs.is_blender_modern else 'TOOLS'
+    bl_region_type = 'UI'
     bl_category = 'MatCombiner'
 
     def draw(self, context: bpy.types.Context) -> None:

--- a/ui/property_panel.py
+++ b/ui/property_panel.py
@@ -135,7 +135,7 @@ class PropertyMenu(bpy.types.Operator):
             col: UI column to add the image display to.
             image: Image to display information for.
         """
-        if globs.is_blender_3_plus and not image.preview:
+        if not image.preview:
             image.preview_ensure()
 
         # Truncate image name if too long
@@ -178,14 +178,6 @@ class PropertyMenu(bpy.types.Operator):
             image: Optional texture image from the material.
         """
         mat = item.mat
-
-        if globs.is_blender_legacy:
-            col.prop(mat, 'smc_diffuse')
-            if not mat.smc_diffuse:
-                return
-
-            col.prop(mat, 'diffuse_color', text='')
-            return
 
         shader = get_shader_type(mat)
         if not shader:
@@ -258,8 +250,4 @@ class PropertyMenu(bpy.types.Operator):
         Returns:
             System DPI value for dialog sizing.
         """
-        return (
-            context.preferences.system.dpi
-            if globs.is_blender_modern
-            else context.user_preferences.system.dpi
-        )
+        return context.preferences.system.dpi

--- a/ui/update_panel.py
+++ b/ui/update_panel.py
@@ -20,7 +20,7 @@ class UpdatePanel(bpy.types.Panel):
     bl_label = "Updates"
     bl_idname = "SMC_PT_Update_Panel"
     bl_space_type = "VIEW_3D"
-    bl_region_type = "UI" if globs.is_blender_modern else "TOOLS"
+    bl_region_type = "UI"
     bl_category = "MatCombiner"
     bl_options = {"DEFAULT_CLOSED"}
 

--- a/utils/materials.py
+++ b/utils/materials.py
@@ -300,9 +300,6 @@ def get_image_from_material(
     Returns:
         The albedo/diffuse image or None if no texture is found.
     """
-    if globs.is_blender_legacy:
-        return get_image(get_texture(mat))
-
     if not mat.node_tree or not mat.node_tree.nodes:
         return None
 
@@ -345,10 +342,7 @@ def get_diffuse(mat: bpy.types.Material) -> Tuple[int, int, int, int]:
     if not mat:
         return diffuse_color
 
-    if globs.is_blender_legacy:
-        return _rgb_to_255_scale(mat.diffuse_color)
-
-    # For Blender 2.80+, use node-based detection
+    # Use node-based detection
     if not mat.node_tree or not mat.node_tree.nodes:
         return diffuse_color
 

--- a/utils/textures.py
+++ b/utils/textures.py
@@ -1,8 +1,7 @@
 """Texture handling utilities for Material Combiner.
 
-This module provides functions for retrieving texture information
-from materials, specifically focusing on Blender Internal textures
-for backward compatibility with older Blender versions.
+This module is maintained for backward compatibility but is not actively used
+in Blender 5.0+ as the addon only supports node-based materials.
 """
 
 from typing import Optional
@@ -11,25 +10,17 @@ import bpy
 
 
 def get_texture(mat: bpy.types.Material) -> Optional[bpy.types.Texture]:
-    """Get the first enabled texture from a material's texture slots.
+    """Get texture from a material's texture slots.
 
-    This function works with Blender Internal materials (pre-2.80)
-    that use texture slots.
+    Note: This function is deprecated and only for legacy compatibility.
+    Blender 5.0+ does not support texture slots. Always returns None.
 
     Args:
         mat: Material to extract texture from.
 
     Returns:
-        First enabled texture from the material or None if not found.
+        None - texture slots are not supported in Blender 5.0+
     """
-    if not hasattr(mat, "texture_slots") or not mat.texture_slots:
-        return None
-
-    return next(
-        (
-            slot.texture
-            for idx, slot in enumerate(mat.texture_slots)
-            if mat.use_textures[idx]
-        ),
-        None,
-    )
+    # Blender 5.0+ does not support texture_slots
+    # All materials must use node-based shaders
+    return None


### PR DESCRIPTION
- Minimum Blender version now 5.0.0
- Remove all legacy Blender < 2.80 code paths
- Remove bl_info from code, move to blender_manifest.toml
- Remove Blender Internal material support
- Simplify version checks and conditional code
- Update all UI panels to use modern region types
- Convert to official Blender Extension format
- Update addon_updater_ops to not depend on bl_info
- Modernize all imports and dependencies
- Update version to 3.0.0
- Update maintainer to Team Neoneko
- Update GitHub repository to teamnemoneko/material-combiner-addon
- Remove Patreon and Buy Me a Coffee support links
- Update Discord link to https://discord.neoneko.xyz/
- Update issue tracker to Team Neoneko repository

This addon is now a proper Blender Extension supporting only Blender 5.0+ with all breaking changes addressed. Material Combiner is now maintained by Team Neoneko while maintaining original author credits.